### PR TITLE
Add option to enable minimal number of adlists that cover all domains that have been analyzed.

### DIFF
--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -633,9 +633,6 @@ echo
 echo
 
 
-# save adlist unique_configuration 
-adlist_conf_unique_enabled=(`sqlite3 $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
-
 if [ "$menu_selection" -eq 1 ]; 
     then
         menu_selection=
@@ -676,6 +673,7 @@ if [ "$menu_selection" -eq 2 ]; then
     echo
     echo "  [i]  Enabling adlists with covered unique domains...."
     sudo sqlite3 $GRAVITY "UPDATE adlist SET enabled=0;"
+    adlist_conf_unique_enabled=(`sqlite3 $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
     for adlist_id in "${adlist_conf_unique_enabled[@]}"; do
        sudo  sqlite3 $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
     done

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -639,12 +639,13 @@ adlist_conf_unique_enabled=(`sqlite3 $TEMP_DB "select id from adlist where uniqu
 if [ "$menu_selection" -eq 1 ]; 
     then
         menu_selection=
-        echo "  Would you like to keep your adlist configuration, or keep only adlists enabled with at least one unique covered domain?"
+        echo "  Would you like to ... "
         echo
-        echo "  1)  Keep adlist configuration" 
+        echo "  1)  Keep your current adlist configuration" 
         echo "  2)  Enable only adlists with covered unique domains"
+        echo "  3)  Enable the minimal number of adlists that cover all domains that would have been blocked"
         echo
-        while [[ $menu_selection != [12] ]]; do
+        while [[ $menu_selection != [123] ]]; do
           read -p "  Please select: " menu_selection
         done
         if [ "$menu_selection" -eq 1 ]; then
@@ -654,13 +655,14 @@ if [ "$menu_selection" -eq 1 ];
 
     else
         menu_selection=
-        echo "  Would you like to keep all adlists enabled, keep only adlists enabled with at least one unique covered domain, or revert to your previous adlist configurartion?"
+        echo "  Would you like to ..."
         echo
         echo "  1)  Keep all adlists enabled" 
         echo "  2)  Enable only adlists with covered unique domains"
-        echo "  3)  Restore previous adlist configuration"
+        echo "  3)  Enable the minimal number of adlists that cover all domains that would have been blocked"
+        echo "  4)  Restore previous adlist configuration"
         echo
-        while [[ $menu_selection != [123] ]]; do
+        while [[ $menu_selection != [1234] ]]; do
           read -p "  Please select: " menu_selection
         done
         if [ "$menu_selection" -eq 1 ]; then
@@ -685,6 +687,22 @@ if [ "$menu_selection" -eq 2 ]; then
 fi
 
 if [ "$menu_selection" -eq 3 ]; then
+    
+    echo
+    echo "  [i]  Enabling minimum number of adlists that cover all domains that would have been blocked...."
+#    sudo sqlite3 $GRAVITY "UPDATE adlist SET enabled=0;"
+#    for adlist_id in "${adlist_conf_unique_enabled[@]}"; do
+#       sudo  sqlite3 $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
+#    done
+#    pihole restartdns reload-lists    
+    echo
+    echo "  [✓]  Minimal number of adlists that cover all domains (that would have been blocked) enabled"
+    echo
+    domains_blocked_future
+fi
+
+
+if [ "$menu_selection" -eq 4 ]; then
 
     echo
     echo "  [i]  Restoring previous adlist configuration...."

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -41,6 +41,8 @@ SQLITE_VERSION=
 NUM_DOMAINS_BLOCKED_FUTURE=
 declare -a adlist_enabled_in_gravity
 declare -i run_gravity_now
+declare -a adlist_conf_minimal_enabled
+left_domains=
 
 
 #for text formating
@@ -688,11 +690,43 @@ if [ "$menu_selection" -eq 3 ]; then
     
     echo
     echo "  [i]  Enabling minimum number of adlists that cover all domains that would have been blocked...."
-#    sudo sqlite3 $GRAVITY "UPDATE adlist SET enabled=0;"
-#    for adlist_id in "${adlist_conf_unique_enabled[@]}"; do
-#       sudo  sqlite3 $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
-#    done
-#    pihole restartdns reload-lists    
+    sudo sqlite3 $GRAVITY "UPDATE adlist SET enabled=0;"
+    
+    # get all adlist_ids with unique domains (same as $adlist_conf_unique_enabled)
+    # create a copy of gravity_strip where domains can be removed from (gravity_strip is used later again)
+    # delete all domains from gravity_dup that are also found on an adlist in the array with the unique domains
+    # repeat until gravity_dup is empty
+    #   get the adlist_id for which there are the most remaining domains on gravity_dup
+    #   add this adlist_id to the array
+    #   remove all domains from gravity_dup that are also contained in that adlist
+    #   count how many domains are still on gravity_dup
+    
+    adlist_conf_minimal_enabled=(`sqlite3 $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
+    
+    sqlite3 $TEMP_DB "CREATE TABLE gravity_dup AS SELECT * FROM gravity_strip"
+    
+    for adlist_id in "${adlist_conf_minimal_enabled[@]}"; do
+       sqlite3 $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$adlist_id);"
+    done
+    
+    left_domains=(`sqlite3 $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"`)
+    
+    while [[ $left_domains != [0] ]]; do
+        current_id=(`sqlite3 $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;"`);
+    
+        adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="$current_id"
+        sqlite3 $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$current_id);"
+        left_domains=(`sqlite3 $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"`)  
+    done
+
+    echo "  [i]  Enabling adlists with id ${adlist_conf_minimal_enabled[@]}"
+
+    for adlist_id in "${adlist_conf_minimal_enabled[@]}"; do
+       sudo  sqlite3 $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
+    done
+    
+    pihole restartdns reload-lists    
+   
     echo
     echo "  [✓]  Minimal number of adlists that cover all domains (that would have been blocked) enabled"
     echo


### PR DESCRIPTION
Previously, if users chose to enable only adlists with unique domains they would have missed domains that have been visited (and would have been blocked) but are not contained on any adlist with unique domains but are **on two ore more** adlists. This new options will include not only adlists with unique domains but also enable the minimal number of additional adlists so that all domains that would have been blocked will be covered in the future with the minimal number of enabled adlists.

For details see https://github.com/yubiuser/pihole_adlist_tool/issues/5

Fixes https://github.com/yubiuser/pihole_adlist_tool/issues/5