### PR TITLE
Enforce and benefit from latest Pi-hole versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ On my [NanoPi NeoPlus2](http://wiki.friendlyarm.com/wiki/index.php/NanoPi_NEO_Pl
 ---
 **Requirements**
 
-- Pihole v5.0
+- Pi-hole FTL v5.5 (see [PR #13](https://github.com/yubiuser/pihole_adlist_tool/pull/13)) 
 
 ---
 ** Usage **

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -43,6 +43,7 @@ declare -a adlist_enabled_in_gravity
 declare -i run_gravity_now
 declare -a adlist_conf_minimal_enabled
 left_domains=
+PIHOLE_FTL_VERSION=
 
 
 #for text formating
@@ -158,6 +159,16 @@ done
 
 warm_up() {
 
+# get Pi-hole version
+PIHOLE_FTL_VERSION=$(pihole-FTL -vv |awk '/dnsmasq/{getline; print substr($2,9)}')
+
+# Enforce an up-to-date pihole version. This also guarantees that the new adlist-filename schema is used, sqlite shell is exposed and CNAME Data is availabe. 
+if [ "$(printf '%s\n' "2.83" "$PIHOLE_FTL_VERSION" | sort -V | head -n1)" = "2.83" ]; then :
+    else
+        echo -e "\n\n  [✗]  ${bold}You're running an old Pi-hole version which is missing important security updates. Please upgrade.${normal}"
+        exit 1
+fi
+
 # exit if $DAYS_REQUESTED is no digit
 case "$DAYS_REQUESTED" in
     ''|*[0-9]*) ;;
@@ -175,6 +186,11 @@ esac
 
 echo -e "\n   ++++++++ Info ++++++++\n"
 
+# print Pi-hole FTL version and SQLite version
+echo -e "  [i]  Pi-hole FTL Version: $PIHOLE_FTL_VERSION"
+
+SQLITE_VERSION=$(pihole-FTL sql --version|awk '{print $1}')
+echo -e "  [i]  SQLITE_VERSION: $SQLITE_VERSION"
 
 # print number of requested days
 if [ "$DAYS_REQUESTED" = 0 ];
@@ -226,6 +242,7 @@ if git -C /etc/.pihole/ log 2> /dev/null |grep -q 73963fecda6dc65b10d1dd3e43a593
 fi
 
 
+
 # does the query database contain the additional info for deep CNAME inspection
 if sqlite3 ${PIHOLE_FTL} "PRAGMA table_info(queries);" |grep -q additional_info ;then
         CNAME_AVAILABLE=1
@@ -234,11 +251,6 @@ if sqlite3 ${PIHOLE_FTL} "PRAGMA table_info(queries);" |grep -q additional_info 
         CNAME_AVAILABLE=0
         echo -e "  [i]  CNAME_AVAILABLE: deep CNAME info not available"
 fi
-
-
-# get and print SQLite version
-SQLITE_VERSION=$(sqlite3 --version|awk '{print $1}')
-echo -e "  [i]  SQLITE_VERSION: $SQLITE_VERSION"
 
 echo -e "\n   ++++++++++++++++++++++\n\n"
 }

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -189,7 +189,7 @@ esac
 echo -e "\n   ++++++++ Info ++++++++\n"
 
 # print Pi-hole FTL version and SQLite version
-echo -e "  [i]  Pi-hole FTL Version: $PIHOLE_FTL_VERSION"
+echo -e "  [i]  PIHOLE_FTL_VERSION: $PIHOLE_FTL_VERSION"
 
 SQLITE_VERSION=$(pihole-FTL sqlite3 --version|awk '{print $1}')
 echo -e "  [i]  SQLITE_VERSION: $SQLITE_VERSION"
@@ -723,5 +723,3 @@ if [ "$UNIQUE" = 1 ];
 fi
 
 remove_temp_database
-
-

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -137,9 +137,14 @@ exit 1
 }
 
 # use pihole-FTL's build-in sql shell
+# putting this in a function allows to easily change to another sqlite engine one day if necssary
 sqlite () {
  pihole-FTL sqlite3 "$@"
 }
+
+# use declare to save the sqlite function, which will be passed by bash -c to the sudo commands 
+# https://unix.stackexchange.com/questions/269078/executing-a-bash-script-function-with-sudo
+SUDO_SQLITE=$(declare -f sqlite)
 
 trap cleanup_on_trap INT
 
@@ -343,7 +348,7 @@ fi
 if [ "$menu_selection" -eq 2 ]; then
 
     echo "  [i]  Enabling all adlists...."
-    sudo sqlite $GRAVITY "UPDATE adlist SET enabled=1;"
+    sudo bash -c "$SUDO_SQLITE; sqlite $GRAVITY 'UPDATE adlist SET enabled=1;'"
     echo
     echo
     echo "  [i]  Starting gravity"
@@ -631,10 +636,10 @@ if [ "$menu_selection" -eq 2 ]; then
     
     echo
     echo "  [i]  Enabling adlists with covered unique domains...."
-    sudo sqlite $GRAVITY "UPDATE adlist SET enabled=0;"
+    sudo bash -c "$SUDO_SQLITE; sqlite $GRAVITY 'UPDATE adlist SET enabled=0;'"
     adlist_conf_unique_enabled=(`sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
     for adlist_id in "${adlist_conf_unique_enabled[@]}"; do
-       sudo  sqlite $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
+       sudo bash -c "$SUDO_SQLITE; sqlite $GRAVITY 'UPDATE adlist SET enabled=1 where id=$adlist_id;'"
     done
     pihole restartdns reload-lists    
     echo
@@ -647,7 +652,7 @@ if [ "$menu_selection" -eq 3 ]; then
     
     echo
     echo "  [i]  Enabling minimum number of adlists that cover all domains that would have been blocked...."
-    sudo sqlite $GRAVITY "UPDATE adlist SET enabled=0;"
+    sudo bash -c "$SUDO_SQLITE; sqlite $GRAVITY 'UPDATE adlist SET enabled=0;'"
     
     # get all adlist_ids with unique domains (same as $adlist_conf_unique_enabled)
     # create a copy of gravity_strip where domains can be removed from (gravity_strip is used later again)
@@ -679,7 +684,7 @@ if [ "$menu_selection" -eq 3 ]; then
     echo "  [i]  Enabling adlists with id ${adlist_conf_minimal_enabled[@]}"
 
     for adlist_id in "${adlist_conf_minimal_enabled[@]}"; do
-       sudo  sqlite $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
+       sudo bash -c "$SUDO_SQLITE; sqlite $GRAVITY 'UPDATE adlist SET enabled=1 where id=$adlist_id;'"
     done
     
     pihole restartdns reload-lists    
@@ -695,9 +700,9 @@ if [ "$menu_selection" -eq 4 ]; then
 
     echo
     echo "  [i]  Restoring previous adlist configuration...."
-    sudo sqlite $GRAVITY "UPDATE adlist SET enabled=0;"
+    udo bash -c "$SUDO_SQLITE; sqlite $GRAVITY 'UPDATE adlist SET enabled=0;'"
     for adlist_id in "${adlist_conf_old_enabled[@]}"; do
-       sudo sqlite $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
+       sudo bash -c "$SUDO_SQLITE; sqlite $GRAVITY 'UPDATE adlist SET enabled=1 where id=$adlist_id;'"
     done
     pihole restartdns reload-lists    
     echo

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -79,8 +79,8 @@ timestamp2date () {
 
 set_timestamps () {
 
-    TIMESTAMP_FIRST_QUERY=$(sqlite3 $PIHOLE_FTL "SELECT MIN(timestamp) FROM queries;") 
-    TIMESTAMP_LAST_QUERY=$(sqlite3 $PIHOLE_FTL "SELECT MAX(timestamp) FROM queries;")
+    TIMESTAMP_FIRST_QUERY=$(sqlite $PIHOLE_FTL "SELECT MIN(timestamp) FROM queries;") 
+    TIMESTAMP_LAST_QUERY=$(sqlite $PIHOLE_FTL "SELECT MAX(timestamp) FROM queries;")
     if [ "$DAYS_REQUESTED" = 0 ];
         then
             TIMESTAMP_REQUESTED=$TIMESTAMP_FIRST_QUERY
@@ -88,7 +88,7 @@ set_timestamps () {
             TIMESTAMP_REQUESTED=$(date +%s)
             TIMESTAMP_REQUESTED=$TIMESTAMP_REQUESTED-86400*${DAYS_REQUESTED}
     fi
-    TIMESTAMP_FIRST_ANALYZED=$(sqlite3 $PIHOLE_FTL "SELECT min(timestamp) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
+    TIMESTAMP_FIRST_ANALYZED=$(sqlite $PIHOLE_FTL "SELECT min(timestamp) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
 }
 
 # converts dates
@@ -106,14 +106,14 @@ set_dates () {
 # which might not contain all domains that could have been blocked or only enable adlists with unique covered domains
 
 domains_blocked_future () {
-sqlite3 $TEMP_DB << EOF
+sqlite $TEMP_DB << EOF
     ATTACH DATABASE "${GRAVITY}?mode=ro" AS gravity_db; 
         INSERT INTO info (property, value) Select 'NUM_DOMAINS_BLOCKED_FUTURE', count(distinct gravity_strip.domain) from gravity_strip join gravity_db.gravity on gravity_strip.domain=gravity_db.gravity.domain Join gravity_db.adlist on gravity_db.gravity.adlist_id=gravity_db.adlist.id where enabled=1;
     DETACH DATABASE gravity_db;
 .exit
 EOF
 
-NUM_DOMAINS_BLOCKED_FUTURE=$(sqlite3 $TEMP_DB "SELECT value FROM info where property='NUM_DOMAINS_BLOCKED_FUTURE';")
+NUM_DOMAINS_BLOCKED_FUTURE=$(sqlite $TEMP_DB "SELECT value FROM info where property='NUM_DOMAINS_BLOCKED_FUTURE';")
 
 echo
 echo "  [✓]  Of the ${bold}"$NUM_DOMAINS_BLOCKED_CURRENT"${normal} domains that would have been blocked by the adlist configuration you chose to analyze,"
@@ -136,6 +136,10 @@ remove_temp_database
 exit 1
 }
 
+# use pihole-FTL's build-in sql shell
+sqlite () {
+ pihole-FTL sqlite3 "$@"
+}
 
 trap cleanup_on_trap INT
 
@@ -187,7 +191,7 @@ echo -e "\n   ++++++++ Info ++++++++\n"
 # print Pi-hole FTL version and SQLite version
 echo -e "  [i]  Pi-hole FTL Version: $PIHOLE_FTL_VERSION"
 
-SQLITE_VERSION=$(pihole-FTL sql --version|awk '{print $1}')
+SQLITE_VERSION=$(pihole-FTL sqlite3 --version|awk '{print $1}')
 echo -e "  [i]  SQLITE_VERSION: $SQLITE_VERSION"
 
 # print number of requested days
@@ -252,7 +256,7 @@ set_timestamps
 set_dates
 
 # get FTL_ID based on $TIMESTAMP_REQUESTED
-FTL_ID=$(sqlite3 $PIHOLE_FTL "SELECT MIN(id) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
+FTL_ID=$(sqlite $PIHOLE_FTL "SELECT MIN(id) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
 
 
 
@@ -277,7 +281,7 @@ fi
 
 
 # save old adlist_configuration 
-adlist_conf_old_enabled=(`sqlite3 $GRAVITY "select id from adlist where enabled=1;"`)
+adlist_conf_old_enabled=(`sqlite $GRAVITY "select id from adlist where enabled=1;"`)
 
 echo "  Would you like to analyze your current adlist configuration or first enable all adlists (current can be restored later)?"
 echo
@@ -297,7 +301,7 @@ if [ "$menu_selection" -eq 1 ]; then
 
     # check if a mismatch between enabled adlists and data in gravity exists, offer to run gravity
     # https://stackoverflow.com/a/28161520
-    adlist_enabled_in_gravity=(`sqlite3 $GRAVITY "select distinct adlist_id from gravity;"`)
+    adlist_enabled_in_gravity=(`sqlite $GRAVITY "select distinct adlist_id from gravity;"`)
     if [ -n "$(echo ${adlist_conf_old_enabled[@]} ${adlist_enabled_in_gravity[@]} | tr ' ' '\n' |sort |uniq -u)" ]; then
 
         echo
@@ -339,7 +343,7 @@ fi
 if [ "$menu_selection" -eq 2 ]; then
 
     echo "  [i]  Enabling all adlists...."
-    sudo sqlite3 $GRAVITY "UPDATE adlist SET enabled=1;"
+    sudo sqlite $GRAVITY "UPDATE adlist SET enabled=1;"
     echo
     echo
     echo "  [i]  Starting gravity"
@@ -376,7 +380,7 @@ echo "  [i]  This might take some time - please be patient."
 
 
 # create $TEMP_DB
-sqlite3 $TEMP_DB << EOF
+sqlite $TEMP_DB << EOF
     create table blocked_domains (domain TEXT UNIQUE,hits INTEGER);
     create table adlist (id INTEGER, enabled INTEGER, address TEXT, total_domains INTEGER, domains_covered INTEGER, hits_covered INTEGER, unique_domains_covered INTEGER);
     create table gravity_strip (domain TEXT,adlist_id INTEGER);
@@ -409,7 +413,7 @@ EOF
 # 10.) update blacklist_cname with the number of hits for each domain
 
 
-sqlite3 -cmd ".timeout 5000" $TEMP_DB << EOF
+sqlite -cmd ".timeout 5000" $TEMP_DB << EOF
     ATTACH DATABASE "${PIHOLE_FTL}" AS pihole_ftl_db;
     ATTACH DATABASE "${GRAVITY}?mode=ro" AS gravity_db;
 
@@ -448,7 +452,7 @@ EOF
 # 4.) counts the number of unique domains covered by each adlist
 # 5-11.) Calculate some statistics
 
-sqlite3 $TEMP_DB << EOF
+sqlite $TEMP_DB << EOF
     INSERT INTO unique_domains(domain, adlist_id) SELECT domain, adlist_id FROM gravity_strip GROUP BY domain HAVING COUNT(domain)==1 order by adlist_id asc;
     UPDATE adlist SET domains_covered=(select count(domain) FROM gravity_strip WHERE id== adlist_id GROUP BY adlist_id);
     UPDATE adlist SET hits_covered=(SELECT SUM(blocked_domains.hits) FROM gravity_strip JOIN blocked_domains ON gravity_strip.domain == blocked_domains.domain WHERE id== adlist_id Group by adlist_id);
@@ -474,22 +478,22 @@ EOF
 
 
 grep -c . /etc/pihole/list* |awk -F '[.:]' '{print $2 " "$NF}' | while read adlist_id count; do
-             sqlite3 $TEMP_DB "UPDATE adlist SET total_domains="${count}" WHERE id="${adlist_id}";"
+             sqlite $TEMP_DB "UPDATE adlist SET total_domains="${count}" WHERE id="${adlist_id}";"
 done
 
 
 # get some statistics
 # the number of domains blocked and hits is the sum of enties with status 1 or 9
-read NUM_DOMAINS_BLOCKED HITS_TOTAL <<<$(sqlite3 -separator " " $PIHOLE_FTL "SELECT COUNT(DISTINCT domain),count(domain) FROM queries WHERE id>=${FTL_ID} AND status in (1,9);")
+read NUM_DOMAINS_BLOCKED HITS_TOTAL <<<$(sqlite -separator " " $PIHOLE_FTL "SELECT COUNT(DISTINCT domain),count(domain) FROM queries WHERE id>=${FTL_ID} AND status in (1,9);")
 
-NUM_ADLISTS=$(sqlite3 $TEMP_DB "SELECT value FROM info where property='NUM_ADLISTS';")
-NUM_ADLISTS_ENABLED=$(sqlite3 $TEMP_DB "SELECT value FROM info where property='NUM_ADLISTS_ENABLED';")
-NUM_DOMAINS_BLOCKED_CURRENT=$(sqlite3 $TEMP_DB "SELECT value FROM info where property='NUM_DOMAINS_BLOCKED_CURRENT';")
-HITS_TOTAL_CURRENT=$(sqlite3 $TEMP_DB "SELECT value FROM info where property='HITS_TOTAL_CURRENT';")
-BLACKLIST_GRAVITY=$(sqlite3 $TEMP_DB "SELECT value FROM info where property='BLACKLIST_GRAVITY';")
-NUM_TOTAL_UNIQUE_DOMAINS=$(sqlite3 $TEMP_DB "SELECT value FROM info where property='NUM_TOTAL_UNIQUE_DOMAINS';")
-BLACKLIST_CNAME=$(sqlite3 $TEMP_DB "SELECT value FROM info where property='BLACKLIST_CNAME';")
-NUM_GRAVITY_UNIQUE_DOMAINS=$(sqlite3 $GRAVITY "SELECT value FROM info WHERE property == 'gravity_count';")
+NUM_ADLISTS=$(sqlite $TEMP_DB "SELECT value FROM info where property='NUM_ADLISTS';")
+NUM_ADLISTS_ENABLED=$(sqlite $TEMP_DB "SELECT value FROM info where property='NUM_ADLISTS_ENABLED';")
+NUM_DOMAINS_BLOCKED_CURRENT=$(sqlite $TEMP_DB "SELECT value FROM info where property='NUM_DOMAINS_BLOCKED_CURRENT';")
+HITS_TOTAL_CURRENT=$(sqlite $TEMP_DB "SELECT value FROM info where property='HITS_TOTAL_CURRENT';")
+BLACKLIST_GRAVITY=$(sqlite $TEMP_DB "SELECT value FROM info where property='BLACKLIST_GRAVITY';")
+NUM_TOTAL_UNIQUE_DOMAINS=$(sqlite $TEMP_DB "SELECT value FROM info where property='NUM_TOTAL_UNIQUE_DOMAINS';")
+BLACKLIST_CNAME=$(sqlite $TEMP_DB "SELECT value FROM info where property='BLACKLIST_CNAME';")
+NUM_GRAVITY_UNIQUE_DOMAINS=$(sqlite $GRAVITY "SELECT value FROM info WHERE property == 'gravity_count';")
 
 
 echo
@@ -517,7 +521,7 @@ if [ "$BLACKLIST_GRAVITY" -ne 0 ]; then
     echo "       adlist, the number of potentially blocked domains/hits is therefore higher."
     echo
     echo
-    sqlite3 -column -header $TEMP_DB "SELECT * FROM blacklist_gravity"
+    sqlite -column -header $TEMP_DB "SELECT * FROM blacklist_gravity"
     echo
     echo "  [i]  Use 'pihole -q DOMAIN' to see which adlist(s) contains the requested domain"
     echo
@@ -537,7 +541,7 @@ if [ "$BLACKLIST_CNAME" -ne 0 ]; then
     echo "       the number of potentially blocked domains/hits is therefore higher."
     echo
     echo
-    sqlite3 -column -header $TEMP_DB "SELECT * FROM blacklist_cname"
+    sqlite -column -header $TEMP_DB "SELECT * FROM blacklist_cname"
     echo
     echo
     echo
@@ -556,7 +560,7 @@ if [ "$TOP" = 0 ]; then :
         echo "       Those would have been the ${bold}"$TOP" top blocked adlist domains${normal} since "$DATE_FIRST_ANALYZED""
         echo "       using your current adlist configuration"
         echo
-        sqlite3 -column -header $TEMP_DB "SELECT domain, hits FROM blocked_domains LIMIT "${TOP}";"
+        sqlite -column -header $TEMP_DB "SELECT domain, hits FROM blocked_domains LIMIT "${TOP}";"
         echo
         echo
         echo
@@ -572,7 +576,7 @@ echo
 echo
 
 # prints the adlist table, sorting depends on -s argument
-sqlite3 -column -header $TEMP_DB "SELECT id, enabled, total_domains, domains_covered, hits_covered, unique_domains_covered, address FROM adlist ORDER BY ${SORT_ORDER};"
+sqlite -column -header $TEMP_DB "SELECT id, enabled, total_domains, domains_covered, hits_covered, unique_domains_covered, address FROM adlist ORDER BY ${SORT_ORDER};"
 
 echo
 echo
@@ -627,10 +631,10 @@ if [ "$menu_selection" -eq 2 ]; then
     
     echo
     echo "  [i]  Enabling adlists with covered unique domains...."
-    sudo sqlite3 $GRAVITY "UPDATE adlist SET enabled=0;"
-    adlist_conf_unique_enabled=(`sqlite3 $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
+    sudo sqlite $GRAVITY "UPDATE adlist SET enabled=0;"
+    adlist_conf_unique_enabled=(`sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
     for adlist_id in "${adlist_conf_unique_enabled[@]}"; do
-       sudo  sqlite3 $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
+       sudo  sqlite $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
     done
     pihole restartdns reload-lists    
     echo
@@ -643,7 +647,7 @@ if [ "$menu_selection" -eq 3 ]; then
     
     echo
     echo "  [i]  Enabling minimum number of adlists that cover all domains that would have been blocked...."
-    sudo sqlite3 $GRAVITY "UPDATE adlist SET enabled=0;"
+    sudo sqlite $GRAVITY "UPDATE adlist SET enabled=0;"
     
     # get all adlist_ids with unique domains (same as $adlist_conf_unique_enabled)
     # create a copy of gravity_strip where domains can be removed from (gravity_strip is used later again)
@@ -654,28 +658,28 @@ if [ "$menu_selection" -eq 3 ]; then
     #   remove all domains from gravity_dup that are also contained in that adlist
     #   count how many domains are still on gravity_dup
     
-    adlist_conf_minimal_enabled=(`sqlite3 $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
+    adlist_conf_minimal_enabled=(`sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
     
-    sqlite3 $TEMP_DB "CREATE TABLE gravity_dup AS SELECT * FROM gravity_strip"
+    sqlite $TEMP_DB "CREATE TABLE gravity_dup AS SELECT * FROM gravity_strip"
     
     for adlist_id in "${adlist_conf_minimal_enabled[@]}"; do
-       sqlite3 $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$adlist_id);"
+       sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$adlist_id);"
     done
     
-    left_domains=(`sqlite3 $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"`)
+    left_domains=(`sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"`)
     
     while [[ $left_domains != [0] ]]; do
-        current_id=(`sqlite3 $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;"`);
+        current_id=(`sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;"`);
     
         adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="$current_id"
-        sqlite3 $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$current_id);"
-        left_domains=(`sqlite3 $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"`)  
+        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$current_id);"
+        left_domains=(`sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"`)  
     done
 
     echo "  [i]  Enabling adlists with id ${adlist_conf_minimal_enabled[@]}"
 
     for adlist_id in "${adlist_conf_minimal_enabled[@]}"; do
-       sudo  sqlite3 $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
+       sudo  sqlite $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
     done
     
     pihole restartdns reload-lists    
@@ -691,9 +695,9 @@ if [ "$menu_selection" -eq 4 ]; then
 
     echo
     echo "  [i]  Restoring previous adlist configuration...."
-    sudo sqlite3 $GRAVITY "UPDATE adlist SET enabled=0;"
+    sudo sqlite $GRAVITY "UPDATE adlist SET enabled=0;"
     for adlist_id in "${adlist_conf_old_enabled[@]}"; do
-       sudo sqlite3 $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
+       sudo sqlite $GRAVITY "UPDATE adlist SET enabled=1 where id=$adlist_id;"
     done
     pihole restartdns reload-lists    
     echo
@@ -713,7 +717,7 @@ if [ "$UNIQUE" = 1 ];
         echo
         echo "  [i]  ${bold}Covered unique domains${normal}"
         echo
-        sqlite3 -column -header $TEMP_DB "SELECT domain, adlist_id, address FROM unique_domains JOIN adlist WHERE adlist_id=id;"
+        sqlite -column -header $TEMP_DB "SELECT domain, adlist_id, address FROM unique_domains JOIN adlist WHERE adlist_id=id;"
         echo
         echo
 fi

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -34,7 +34,6 @@ NUM_TOTAL_UNIQUE_DOMAINS=
 declare -a adlist_conf_old_enabled
 declare -a adlist_conf_unique_enabled
 declare -i menu_selection
-NEW_ADLIST_FILENAME_SCHEMA=
 CNAME_AVAILABLE=
 BLACKLIST_CNAME=
 SQLITE_VERSION=
@@ -231,16 +230,6 @@ if [ "$UNIQUE" -eq 1 ];
     else
         echo -e "  [i]  UNIQUE: Not shown"
 fi       
-
-# Is the new adlist filename schema used
-if git -C /etc/.pihole/ log 2> /dev/null |grep -q 73963fecda6dc65b10d1dd3e43a5931dc531304a; then
-        NEW_ADLIST_FILENAME_SCHEMA=1
-        echo -e "  [i]  NEW_ADLIST_FILENAME_SCHEMA: yes"
-    else
-        NEW_ADLIST_FILENAME_SCHEMA=0
-        echo -e "  [i]  NEW_ADLIST_FILENAME_SCHEMA: no"
-fi
-
 
 
 # does the query database contain the additional info for deep CNAME inspection
@@ -511,20 +500,13 @@ EOF
 # Since commit 73963fecda6dc65b10d1dd3e43a5931dc531304a to pihole's core, locally saved adlist copies contain the adlist_id in the filename.
 # We can use that to count the lines in each file and use the adlist_id to attribute it to the corresponding adlist in TEMP_DB
 # This is faster than to count the domains for each adlist from gravity_db
-# We use the new method only if the commit is found in the local git log to ensure that the new filename schema is used
+# note: in a next Pi-hole version, Pi-hole will store the number of domains for each adlist as additional info. This can then be used.
 
 
 
-if [ "$NEW_ADLIST_FILENAME_SCHEMA" = 1 ]; then
-        grep -c . /etc/pihole/list* |awk -F '[.:]' '{print $2 " "$NF}' | while read adlist_id count; do
+grep -c . /etc/pihole/list* |awk -F '[.:]' '{print $2 " "$NF}' | while read adlist_id count; do
              sqlite3 $TEMP_DB "UPDATE adlist SET total_domains="${count}" WHERE id="${adlist_id}";"
-        done
-    else
-        sqlite3 -separator " " $GRAVITY "SELECT adlist_id,count(domain) FROM gravity GROUP BY adlist_id;" | while read adlist_id count; do
-            sqlite3 $TEMP_DB "UPDATE adlist SET total_domains="${count}" WHERE id="${adlist_id}";"
-        done
-fi
-
+done
 
 
 # get some statistics

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -41,7 +41,7 @@ declare -a adlist_enabled_in_gravity
 declare -i run_gravity_now
 declare -a adlist_conf_minimal_enabled
 left_domains=
-PIHOLE_FTL_VERSION=
+PIHOLE_DNSMASQ_VERSION=
 
 
 #for text formating
@@ -166,11 +166,11 @@ done
 
 warm_up() {
 
-# get Pi-hole version
-PIHOLE_FTL_VERSION=$(pihole-FTL -vv |awk '/dnsmasq/{getline; print substr($2,9)}')
+# get Pi-hole's dnsmasq version
+PIHOLE_DNSMASQ_VERSION=$(pihole-FTL -vv |awk '/dnsmasq/{getline; print substr($2,9)}')
 
 # Enforce an up-to-date pihole version. This also guarantees that the new adlist-filename schema is used, sqlite shell is exposed and CNAME Data is availabe. 
-if [ "$(printf '%s\n' "2.83" "$PIHOLE_FTL_VERSION" | sort -V | head -n1)" = "2.83" ]; then :
+if [ "$(printf '%s\n' "2.83" "$PIHOLE_DNSMASQ_VERSION" | sort -V | head -n1)" = "2.83" ]; then :
     else
         echo -e "\n\n  [✗]  ${bold}You're running an old Pi-hole version which is missing important security updates. Please upgrade.${normal}"
         exit 1
@@ -194,7 +194,7 @@ esac
 echo -e "\n   ++++++++ Info ++++++++\n"
 
 # print Pi-hole FTL version and SQLite version
-echo -e "  [i]  PIHOLE_FTL_VERSION: $PIHOLE_FTL_VERSION"
+echo -e "  [i]  PIHOLE_DNSMASQ_VERSION: $PIHOLE_DNSMASQ_VERSION"
 
 SQLITE_VERSION=$(pihole-FTL sqlite3 --version|awk '{print $1}')
 echo -e "  [i]  SQLITE_VERSION: $SQLITE_VERSION"
@@ -480,8 +480,6 @@ EOF
 # This is faster than to count the domains for each adlist from gravity_db
 # note: in a next Pi-hole version, Pi-hole will store the number of domains for each adlist as additional info. This can then be used.
 
-
-
 grep -c . /etc/pihole/list* |awk -F '[.:]' '{print $2 " "$NF}' | while read adlist_id count; do
              sqlite $TEMP_DB "UPDATE adlist SET total_domains="${count}" WHERE id="${adlist_id}";"
 done
@@ -658,10 +656,10 @@ if [ "$menu_selection" -eq 3 ]; then
     # create a copy of gravity_strip where domains can be removed from (gravity_strip is used later again)
     # delete all domains from gravity_dup that are also found on an adlist in the array with the unique domains
     # repeat until gravity_dup is empty
-    #   get the adlist_id for which there are the most remaining domains on gravity_dup
-    #   add this adlist_id to the array
-    #   remove all domains from gravity_dup that are also contained in that adlist
-    #   count how many domains are still on gravity_dup
+    # get the adlist_id for which there are the most remaining domains on gravity_dup
+    # add this adlist_id to the array
+    # remove all domains from gravity_dup that are also contained in that adlist
+    # count how many domains are still on gravity_dup
     
     adlist_conf_minimal_enabled=(`sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
     
@@ -700,7 +698,7 @@ if [ "$menu_selection" -eq 4 ]; then
 
     echo
     echo "  [i]  Restoring previous adlist configuration...."
-    udo bash -c "$SUDO_SQLITE; sqlite $GRAVITY 'UPDATE adlist SET enabled=0;'"
+    sudo bash -c "$SUDO_SQLITE; sqlite $GRAVITY 'UPDATE adlist SET enabled=0;'"
     for adlist_id in "${adlist_conf_old_enabled[@]}"; do
        sudo bash -c "$SUDO_SQLITE; sqlite $GRAVITY 'UPDATE adlist SET enabled=1 where id=$adlist_id;'"
     done

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -34,7 +34,6 @@ NUM_TOTAL_UNIQUE_DOMAINS=
 declare -a adlist_conf_old_enabled
 declare -a adlist_conf_unique_enabled
 declare -i menu_selection
-CNAME_AVAILABLE=
 BLACKLIST_CNAME=
 SQLITE_VERSION=
 NUM_DOMAINS_BLOCKED_FUTURE=
@@ -231,16 +230,6 @@ if [ "$UNIQUE" -eq 1 ];
         echo -e "  [i]  UNIQUE: Not shown"
 fi       
 
-
-# does the query database contain the additional info for deep CNAME inspection
-if sqlite3 ${PIHOLE_FTL} "PRAGMA table_info(queries);" |grep -q additional_info ;then
-        CNAME_AVAILABLE=1
-        echo -e "  [i]  CNAME_AVAILABLE: deep CNAME info available"
-    else
-        CNAME_AVAILABLE=0
-        echo -e "  [i]  CNAME_AVAILABLE: deep CNAME info not available"
-fi
-
 echo -e "\n   ++++++++++++++++++++++\n\n"
 }
 
@@ -363,12 +352,6 @@ if [ "$menu_selection" -eq 2 ]; then
     echo
 fi
 
-# if sqlite3 version <3.24.0, deactivate CNAME analysis, as at least this version is needed for UPSERT sql syntax in CNAME analysis
-if [ "$(printf '%s\n' "3.24.0" "$SQLITE_VERSION" | sort -V | head -n1)" = "3.24.0" ] && [ "$CNAME_AVAILABLE" = 1 ]; then :
- else
-        echo -e "\n  [i]  CNAME info availabe but SQLite version < 3.24.0. Deactivating CNAME analysis\n"
-        CNAME_AVAILABLE=0
-fi
 echo
 echo
 echo "  [i]  Calculating....."
@@ -415,8 +398,15 @@ EOF
 # 4.) select all domains that are on the blacklist and also found in gravity_strip
 # 5.) update blacklist_gravity with the number of hits for each domain (must be done before CNAME handling, as this adds hits to domains found during CNAME instection) 
 
+# CNAME handling
 
-
+# 6.) table cname selects all domains from pihole-ftl.db (additional_info) that that are also found in gravity.db and have status=9. 
+#   (status=9 == "Domain contained in gravity database & Blocked during deep CNAME inspection". This is just being cautious, because "additional_info" might contain other domains in the future for purposes different than CNAME inspection)
+# 7.) add blocked domains (found by deep CNAME inspection) to gravity_strip
+# 8.) add domain and hits found during cname analysis to blocked_domains; if domain is already on the list, onyl update the hit counter
+#    (this is the critical step - "upsert" function was introduced frist in sqlite with 3.24)
+# 9.) select all domains that are on the blacklist and also found during deep CNAME inspection
+# 10.) update blacklist_cname with the number of hits for each domain
 
 
 sqlite3 -cmd ".timeout 5000" $TEMP_DB << EOF
@@ -433,42 +423,21 @@ sqlite3 -cmd ".timeout 5000" $TEMP_DB << EOF
 
     UPDATE blacklist_gravity SET hits=(SELECT blocked_domains.hits FROM blocked_domains WHERE blocked_domains.domain=blacklist_gravity.domain);
 
+    INSERT INTO cname(additional_info, hits) SELECT additional_info, COUNT(domain) FROM pihole_ftl_db.queries WHERE EXISTS (select 1 from gravity_db.gravity where gravity.domain=queries.additional_info) AND id>=${FTL_ID} AND status=9 GROUP BY additional_info ORDER BY COUNT(additional_info) DESC;
+        
+    INSERT OR IGNORE INTO gravity_strip(domain,adlist_id) SELECT gravity_db.gravity.domain, gravity_db.gravity.adlist_id FROM gravity JOIN cname ON cname.additional_info = gravity.domain;
+        
+    INSERT INTO blocked_domains (domain, hits) SELECT additional_info,hits FROM cname  WHERE true ON CONFLICT(domain) DO UPDATE SET hits=hits+(SELECT hits FROM cname);
+
+    INSERT INTO blacklist_cname(domain) SELECT cname.additional_info FROM cname JOIN gravity_db.domainlist on cname.additional_info=gravity_db.domainlist.domain WHERE type==1 GROUP BY cname.additional_info;
+
+    UPDATE blacklist_cname SET hits=(SELECT cname.hits FROM cname WHERE cname.additional_info=blacklist_cname.domain);
+
     DETACH DATABASE gravity_db;
     DETACH DATABASE pihole_ftl_db;
 .exit
 EOF
 
-# CNAME handling
-
-# onyl executed if CNAME_AVAILABE is still 1 (also after SQLite check)
-# 1.) table cname selects all domains from pihole-ftl.db (additional_info) that that are also found in gravity.db and have status=9. 
-#   (status=9 == "Domain contained in gravity database & Blocked during deep CNAME inspection". This is just being cautious, because "additional_info" might contain other domains in the future for purposes different than CNAME inspection)
-# 2.) add blocked domains (found by deep CNAME inspection) to gravity_strip
-# 3.) add domain and hits found during cname analysis to blocked_domains; if domain is already on the list, onyl update the hit counter
-#    (this is the critical step - "upsert" function was introduced frist in sqlite with 3.24)
-# 4.) select all domains that are on the blacklist and also found during deep CNAME inspection
-# 5.) update blacklist_cname with the number of hits for each domain
-
-if [ "$CNAME_AVAILABLE" = 1 ]; then
-    sqlite3 -cmd ".timeout 5000" $TEMP_DB << EOF
-        ATTACH DATABASE "${PIHOLE_FTL}" AS pihole_ftl_db;
-        ATTACH DATABASE "${GRAVITY}?mode=ro" AS gravity_db;
-
-        INSERT INTO cname(additional_info, hits) SELECT additional_info, COUNT(domain) FROM pihole_ftl_db.queries WHERE EXISTS (select 1 from gravity_db.gravity where gravity.domain=queries.additional_info) AND id>=${FTL_ID} AND status=9 GROUP BY additional_info ORDER BY COUNT(additional_info) DESC;
-        
-        INSERT OR IGNORE INTO gravity_strip(domain,adlist_id) SELECT gravity_db.gravity.domain, gravity_db.gravity.adlist_id FROM gravity JOIN cname ON cname.additional_info = gravity.domain;
-        
-        INSERT INTO blocked_domains (domain, hits) SELECT additional_info,hits FROM cname  WHERE true ON CONFLICT(domain) DO UPDATE SET hits=hits+(SELECT hits FROM cname);
-
-        INSERT INTO blacklist_cname(domain) SELECT cname.additional_info FROM cname JOIN gravity_db.domainlist on cname.additional_info=gravity_db.domainlist.domain WHERE type==1 GROUP BY cname.additional_info;
-
-        UPDATE blacklist_cname SET hits=(SELECT cname.hits FROM cname WHERE cname.additional_info=blacklist_cname.domain);
-
-        DETACH DATABASE gravity_db;
-        DETACH DATABASE pihole_ftl_db;
-.exit
-EOF
-fi
    
 # finsih database work in $TEMP_DB
 #
@@ -510,13 +479,8 @@ done
 
 
 # get some statistics
-# depending on CNAME_AVAILABLE, the number of domains blocked and hits is the sum of enties with status 1 or (1 and 9)
-if [ "$CNAME_AVAILABLE" = 1 ]; then
-        read NUM_DOMAINS_BLOCKED HITS_TOTAL <<<$(sqlite3 -separator " " $PIHOLE_FTL "SELECT COUNT(DISTINCT domain),count(domain) FROM queries WHERE id>=${FTL_ID} AND status in (1,9);")
-    else
-        read NUM_DOMAINS_BLOCKED HITS_TOTAL <<<$(sqlite3 -separator " " $PIHOLE_FTL "SELECT COUNT(DISTINCT domain),count(domain) FROM queries WHERE id>=${FTL_ID} AND status == 1;")
-fi
-
+# the number of domains blocked and hits is the sum of enties with status 1 or 9
+read NUM_DOMAINS_BLOCKED HITS_TOTAL <<<$(sqlite3 -separator " " $PIHOLE_FTL "SELECT COUNT(DISTINCT domain),count(domain) FROM queries WHERE id>=${FTL_ID} AND status in (1,9);")
 
 NUM_ADLISTS=$(sqlite3 $TEMP_DB "SELECT value FROM info where property='NUM_ADLISTS';")
 NUM_ADLISTS_ENABLED=$(sqlite3 $TEMP_DB "SELECT value FROM info where property='NUM_ADLISTS_ENABLED';")
@@ -532,15 +496,10 @@ echo
 echo "  [i]  You have ${bold}"$NUM_ADLISTS" adlists${normal} configured ("$NUM_ADLISTS_ENABLED" enabled)" 
 echo "  [i]  Your gravity.db contains ${bold}"$NUM_GRAVITY_UNIQUE_DOMAINS" unique domains${normal}"
 
-if [ "$CNAME_AVAILABLE" = 1 ]; then
-        echo "  [i]  Since "$DATE_FIRST_ANALYZED" ${bold}"$NUM_DOMAINS_BLOCKED" different domains${normal} from your adlists have been blocked ${bold}"$HITS_TOTAL" times${normal} in total"
-        echo "       (blocked directly by gravity or during deep CNAME inspection)"
-        echo "  [i]  Using you current adlist configuration ${bold}"$NUM_DOMAINS_BLOCKED_CURRENT" domains${normal} would have been blocked ${bold}"$HITS_TOTAL_CURRENT" times${normal}"
-    else
-        echo "  [i]  Since "$DATE_FIRST_ANALYZED" ${bold}"$NUM_DOMAINS_BLOCKED" different domains${normal} from your adlists have been blocked ${bold}"$HITS_TOTAL" times${normal} in total"
-        echo "       (blocked by gravity only)"
-        echo "  [i]  Using you current adlist configuration ${bold}"$NUM_DOMAINS_BLOCKED_CURRENT" domains${normal} would have been blocked ${bold}"$HITS_TOTAL_CURRENT" times${normal}"
-fi
+echo "  [i]  Since "$DATE_FIRST_ANALYZED" ${bold}"$NUM_DOMAINS_BLOCKED" different domains${normal} from your adlists have been blocked ${bold}"$HITS_TOTAL" times${normal} in total"
+echo "       (blocked directly by gravity or during deep CNAME inspection)"
+echo "  [i]  Using you current adlist configuration ${bold}"$NUM_DOMAINS_BLOCKED_CURRENT" domains${normal} would have been blocked ${bold}"$HITS_TOTAL_CURRENT" times${normal}"
+
 
 echo
 echo


### PR DESCRIPTION
**This is a breaking change**
The latest version of [Pi-hole FTL (v.5.5) contained a few important security fixes](https://discourse.pi-hole.net/t/pi-hole-ftl-v5-5-released-update-today/43176/1), esp. including `dnsmasq 2.83.`
This PR enforces this or newer versions to nugde users to upgrade. As a side effect the code of the adlist tool could be cleaned clearly, as we can now assume that
1) CNAME data is available
2) the new adlist_filename schema is used

Additionally, since [Pi-hole FTL v.5.4, the build-in sqlite3 shell is exposed](https://discourse.pi-hole.net/t/pi-hole-core-v5-2-3-web-v5-3-and-ftl-v5-4-released/43009). This script now uses this sqlite shell, which guarantees a recent sqlite version (necessary for the UPSERT command) independently of the locally installed sqlite package. 

