### PR TITLE
Fix Issue 36 🚨 shellcheck'ed

### DIFF
--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -1,25 +1,5 @@
 #!/bin/bash
-# ---
-# shellcheck disable=SC2068
-# shellcheck disable=SC2145
-# shellcheck disable=SC2027
-# shellcheck disable=SC2046
-# shellcheck disable=SC2125
-# shellcheck disable=SC2128
-# shellcheck disable=SC2166
-# shellcheck disable=SC2207
-# ---
-# For more information:
-# ---
-#  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
-#  https://www.shellcheck.net/wiki/SC2145 -- Argument mixes string and array. ...
-#  https://www.shellcheck.net/wiki/SC2027 -- The surrounding quotes actually u...
-#  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
-#  https://www.shellcheck.net/wiki/SC2125 -- Brace expansions and globs are li...
-#  https://www.shellcheck.net/wiki/SC2128 -- Expanding an array without an ind...
-#  https://www.shellcheck.net/wiki/SC2166 -- Prefer [ p ] && [ q ] as [ p -a q...
-#  https://www.shellcheck.net/wiki/SC2207 -- Prefer mapfile or read -a to spli...
-# ---
+
 PIHOLE_ADLIST_TOOL_VERSION="2.6.1"
 
 # define path to pihole's databases and temporary database
@@ -161,7 +141,7 @@ set_timestamps () {
             TIMESTAMP_REQUESTED=$TIMESTAMP_FIRST_QUERY
         else
             TIMESTAMP_REQUESTED=$(date +%s)
-            TIMESTAMP_REQUESTED=$TIMESTAMP_REQUESTED-86400*${DAYS_REQUESTED}
+            TIMESTAMP_REQUESTED="$TIMESTAMP_REQUESTED-86400*${DAYS_REQUESTED}"
     fi
     TIMESTAMP_FIRST_ANALYZED=$(sqlite "$PIHOLE_FTL" "SELECT min(timestamp) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
 }
@@ -208,12 +188,12 @@ if [ "$PIHOLE_DOCKER" = 0 ];
 fi
 
 
-echo -e "  [i]  Temporary database removed\n"
+echo -e "  [✓]  Temporary database removed\n"
 }
 
 # cleanup on trap
 cleanup_on_trap () {
-echo -e "\n\n  [x]  ${bold}User-abort detected!${normal}"
+echo -e "\n\n  [✗]  ${bold}User-abort detected!${normal}"
 remove_temp_database
 exit 1
 }
@@ -380,7 +360,7 @@ fi
 
 # verify if there is an update available
 remote_version=$(fetch_remote_version)
-if [ -n "$remote_version" -a "$remote_version" != "$PIHOLE_ADLIST_TOOL_VERSION" ]; then
+if [ -n "$remote_version" ] && [ "$remote_version" != "$PIHOLE_ADLIST_TOOL_VERSION" ]; then
 	echo -e "  [i]  There is an update available: $remote_version"
 fi
 
@@ -424,14 +404,14 @@ fi
 if [ "$TIMESTAMP_REQUESTED" -lt "$TIMESTAMP_FIRST_QUERY" ];
     then
         echo
-        echo -e "  [i]  ${bold}Warning:${normal} You requested to analyze the last ""${DAYS_REQUESTED}"" days (starting from ""$DATE_REQUESTED""),"
-        echo -e "       but oldest query is from ""$DATE_FIRST_QUERY"". Using this instead\n"
+        echo -e "  [i]  ${bold}Warning:${normal} You requested to analyze the last ${DAYS_REQUESTED} days (starting from $DATE_REQUESTED),"
+        echo -e "       but oldest query is from $DATE_FIRST_QUERY. Using this instead\n"
         echo
 fi
 
 
 # save old adlist_configuration
-adlist_conf_old_enabled=($(sqlite $GRAVITY "select id from adlist where enabled=1;"))
+mapfile -t adlist_conf_old_enabled < <(sqlite $GRAVITY "select id from adlist where enabled=1;")
 
 echo "  Would you like to analyze your current adlist configuration or first enable all adlists (current can be restored later)?"
 echo
@@ -461,12 +441,12 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 1 ]; then
 
     # check if a mismatch between enabled adlists and data in gravity exists, offer to run gravity
     # https://stackoverflow.com/a/28161520
-    adlist_conf_old_enabled=($(sqlite $GRAVITY "select id from adlist where enabled=1;"))
-    if [ -n "$(echo ${adlist_conf_old_enabled[@]} ${adlist_enabled_in_gravity[@]} | tr ' ' '\n' |sort |uniq -u)" ]; then
+    mapfile -t adlist_enabled_in_gravity < <(sqlite $GRAVITY "select id from adlist where enabled=1;")
+    if [ -n "$(echo "${adlist_conf_old_enabled[@]}" "${adlist_enabled_in_gravity[@]}" | tr ' ' '\n' |sort |uniq -u)" ]; then
 
         echo
         echo "  [i]  There is a mismatch between your enabled adlists and the data found in the gravity database."
-        echo "       You have ${bold}"${#adlist_conf_old_enabled[@]}"${normal} adlists enabled, but data from ${bold}"${#adlist_enabled_in_gravity[@]}"${normal} (patially different) adlists in your gravity database."
+        echo "       You have ${bold}${#adlist_conf_old_enabled[@]}${normal} adlists enabled, but data from ${bold}${#adlist_enabled_in_gravity[@]}${normal} (patially different) adlists in your gravity database."
         echo "       You're likely disabled/enabled adlist without running gravity afterwards."
         echo "       It's highly recommended to run gravity now to solve the differences, otherwise this tool will analyze the available data."
         echo
@@ -657,7 +637,7 @@ EOF
 
 # get some statistics
 # the number of domains blocked and hits is the sum of enties with status 1 or 9
-read -r NUM_DOMAINS_BLOCKED HITS_TOTAL <<<$(sqlite -separator " " "$PIHOLE_FTL" "SELECT COUNT(DISTINCT domain),count(domain) FROM queries WHERE id>=${FTL_ID} AND status in (1,9);")
+read -r NUM_DOMAINS_BLOCKED HITS_TOTAL <<<"$(sqlite -separator " " "$PIHOLE_FTL" "SELECT COUNT(DISTINCT domain),count(domain) FROM queries WHERE id>=${FTL_ID} AND status in (1,9);")"
 
 NUM_ADLISTS=$(sqlite $TEMP_DB "SELECT value FROM info where property='NUM_ADLISTS';")
 NUM_ADLISTS_ENABLED=$(sqlite $TEMP_DB "SELECT value FROM info where property='NUM_ADLISTS_ENABLED';")
@@ -670,11 +650,11 @@ NUM_GRAVITY_UNIQUE_DOMAINS=$(sqlite $GRAVITY "SELECT value FROM info WHERE prope
 
 
 echo
-echo "  [i]  You have ${bold}""$NUM_ADLISTS"" adlists${normal} configured (""$NUM_ADLISTS_ENABLED"" enabled)"
-echo "  [i]  Your gravity.db contains ${bold}""$NUM_GRAVITY_UNIQUE_DOMAINS"" unique domains${normal}"
-echo "  [i]  Since ""$DATE_FIRST_ANALYZED"" ${bold}""$NUM_DOMAINS_BLOCKED"" different domains${normal} from your adlists have been blocked ${bold}""$HITS_TOTAL"" times${normal} in total"
+echo "  [i]  You have ${bold}$NUM_ADLISTS adlists${normal} configured ($NUM_ADLISTS_ENABLED enabled)"
+echo "  [i]  Your gravity.db contains ${bold}$NUM_GRAVITY_UNIQUE_DOMAINS unique domains${normal}"
+echo "  [i]  Since $DATE_FIRST_ANALYZED ${bold}$NUM_DOMAINS_BLOCKED different domains${normal} from your adlists have been blocked ${bold}$HITS_TOTAL times${normal} in total"
 echo "       (blocked directly by gravity or during deep CNAME inspection)"
-echo "  [i]  Using you current adlist configuration ${bold}""$NUM_DOMAINS_BLOCKED_CURRENT"" domains${normal} would have been blocked ${bold}""$HITS_TOTAL_CURRENT"" times${normal}"
+echo "  [i]  Using you current adlist configuration ${bold}$NUM_DOMAINS_BLOCKED_CURRENT domains${normal} would have been blocked ${bold}$HITS_TOTAL_CURRENT times${normal}"
 
 echo
 echo
@@ -726,10 +706,10 @@ if [ "$TOP" = 0 ]; then :
     else
         echo
         echo "  [i]  ${bold}Top blocked adlist domains${normal}"
-        echo "       Those would have been the ${bold}""$TOP"" top blocked adlist domains${normal} since ""$DATE_FIRST_ANALYZED"""
+        echo "       Those would have been the ${bold}$TOP top blocked adlist domains${normal} since $DATE_FIRST_ANALYZED"
         echo "       using your current adlist configuration"
         echo
-        sqlite -column -header $TEMP_DB "SELECT domain, hits FROM blocked_domains LIMIT ""${TOP}"";"
+        sqlite -column -header $TEMP_DB "SELECT domain, hits FROM blocked_domains LIMIT ${TOP};"
         echo
         echo
         echo
@@ -813,7 +793,7 @@ if [ "$FURTHER_ACTION" -eq 2 ]; then
            sqlite $GRAVITY "UPDATE adlist SET enabled=0;"
     fi
 
-    adlist_conf_unique_enabled=($(sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"))
+    mapfile -t adlist_conf_unique_enabled < <(sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;")
     for adlist_id in "${adlist_conf_unique_enabled[@]}"; do
 
         if [ "$PIHOLE_DOCKER" = 0 ];
@@ -857,7 +837,7 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
     # remove all domains from gravity_dup that are also contained in that adlist
     # count how many domains are still on gravity_dup
 
-    adlist_conf_minimal_enabled=($(sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"))
+    mapfile -t adlist_conf_minimal_enabled < <(sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;")
 
     sqlite $TEMP_DB "CREATE TABLE gravity_dup AS SELECT * FROM gravity_strip"
 
@@ -865,18 +845,18 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$adlist_id);"
     done
 
-    LEFT_DOMAINS=($(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"))
+    mapfile -t LEFT_DOMAINS < <(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
 
-    while [[ $LEFT_DOMAINS != [0] ]]; do
-        current_id=($(sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;"));
+    while [[ ${LEFT_DOMAINS[*]} != [0] ]]; do
+        mapfile -t current_id < <(sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;");
 
-        adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="$current_id"
-        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$current_id);"
-        LEFT_DOMAINS=($(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"))
+        adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="${current_id[*]}"
+        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=${current_id[*]});"
+        mapfile -t LEFT_DOMAINS < <(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
     done
 
     echo
-    echo "  [i]  Enabling adlists with id ${adlist_conf_minimal_enabled[@]}"
+    echo "  [i]  Enabling adlists with id ${adlist_conf_minimal_enabled[*]}"
 
     for adlist_id in "${adlist_conf_minimal_enabled[@]}"; do
 
@@ -1005,7 +985,7 @@ EOF
 # NOTE: pihole-FTL regex-test will test also against RegEx whitelist BUT this is still much faster than to create a second loop to check against each RegEx blacklist indiviually
 
 
-        all_domains=($(sqlite $TEMP_DB "SELECT domain FROM all_domains"))
+        mapfile -t all_domains < <(sqlite $TEMP_DB "SELECT domain FROM all_domains")
 
         for CURRENT_DOMAIN in "${all_domains[@]}"; do
                 pihole-FTL regex-test "$CURRENT_DOMAIN" |grep -E -o "DB ID [0-9]*"|awk '{print $3}' | while read -r REGEX_ID; do
@@ -1024,7 +1004,7 @@ EOF
 # for each domain check if it is covered by a RegEx (using pihole-FTL regex-test)
 # if the test returns regex_ids, save them in domainlist_regex
 
-        all_exact_domains=($(sqlite $GRAVITY "SELECT domain FROM domainlist WHERE type in (0,1);"))
+        mapfile -t all_exact_domains < <(sqlite $GRAVITY "SELECT domain FROM domainlist WHERE type in (0,1);")
 
         for CURRENT_DOMAIN in "${all_exact_domains[@]}"; do
           pihole-FTL regex-test "$CURRENT_DOMAIN" |grep -E -o "DB ID [0-9]*"|awk '{print $3}' | while read -r REGEX_ID; do

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -851,7 +851,7 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
     while [[ ${LEFT_DOMAINS} != 0 ]]; do
         current_id=$(sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;");
 
-        adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="${current_id[*]}"
+        adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="${current_id}"
         sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=${current_id[*]});"
         mapfile -t LEFT_DOMAINS < <(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
     done

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -853,7 +853,7 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
 
         adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="${current_id}"
         sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=${current_id});"
-        mapfile -t LEFT_DOMAINS < <(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
+        LEFT_DOMAINS=$(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
     done
 
     echo

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -857,7 +857,7 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
     done
 
     echo
-    echo "  [✓]  Enabling adlists with id ${adlist_conf_minimal_enabled[*]}"
+    echo "  [i]  Enabling adlists with id ${adlist_conf_minimal_enabled[@]}"
 
     for adlist_id in "${adlist_conf_minimal_enabled[@]}"; do
 

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -852,7 +852,7 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
         current_id=$(sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;");
 
         adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="${current_id}"
-        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=${current_id[*]});"
+        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=${current_id});"
         mapfile -t LEFT_DOMAINS < <(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
     done
 

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -850,8 +850,8 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
     while [[ ${LEFT_DOMAINS} != 0 ]]; do
         current_id=$(sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;");
 
-        adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="${current_id}"
-        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=${current_id});"
+        adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="$current_id"
+        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$current_id);"
         LEFT_DOMAINS=$(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
     done
 

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -441,7 +441,7 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 1 ]; then
 
     # check if a mismatch between enabled adlists and data in gravity exists, offer to run gravity
     # https://stackoverflow.com/a/28161520
-    adlist_enabled_in_gravity=( "$(sqlite "$GRAVITY" "select distinct adlist_id from gravity;")" )
+    mapfile -t adlist_enabled_in_gravity < <(sqlite "$GRAVITY" "select distinct adlist_id from gravity;")
     if [ -n "$(echo "${adlist_conf_old_enabled[@]}" "${adlist_enabled_in_gravity[@]}" | tr ' ' '\n' |sort |uniq -u)" ]; then
 
         echo

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -441,7 +441,7 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 1 ]; then
 
     # check if a mismatch between enabled adlists and data in gravity exists, offer to run gravity
     # https://stackoverflow.com/a/28161520
-    mapfile -t adlist_enabled_in_gravity < <(sqlite $GRAVITY "select id from adlist where enabled=1;")
+    adlist_enabled_in_gravity=$(sqlite $GRAVITY "select distinct adlist_id from gravity;")
     if [ -n "$(echo "${adlist_conf_old_enabled[@]}" "${adlist_enabled_in_gravity[@]}" | tr ' ' '\n' |sort |uniq -u)" ]; then
 
         echo
@@ -856,7 +856,7 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
     done
 
     echo
-    echo "  [i]  Enabling adlists with id ${adlist_conf_minimal_enabled[*]}"
+    echo "  [✓]  Enabling adlists with id ${adlist_conf_minimal_enabled[*]}"
 
     for adlist_id in "${adlist_conf_minimal_enabled[@]}"; do
 

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -441,7 +441,7 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 1 ]; then
 
     # check if a mismatch between enabled adlists and data in gravity exists, offer to run gravity
     # https://stackoverflow.com/a/28161520
-    adlist_enabled_in_gravity=$(sqlite $GRAVITY "select distinct adlist_id from gravity;")
+    adlist_enabled_in_gravity=( "$(sqlite "$GRAVITY" "select distinct adlist_id from gravity;")" )
     if [ -n "$(echo "${adlist_conf_old_enabled[@]}" "${adlist_enabled_in_gravity[@]}" | tr ' ' '\n' |sort |uniq -u)" ]; then
 
         echo
@@ -848,7 +848,7 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
     declare -i LEFT_DOMAINS
     LEFT_DOMAINS=$(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
 
-    while [[ ${LEFT_DOMAINS[*]} != [0] ]]; do
+    while [[ ${LEFT_DOMAINS} != 0 ]]; do
         current_id=$(sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;");
 
         adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="${current_id[*]}"

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -1,5 +1,26 @@
 #!/bin/bash
-PIHOLE_ADLIST_TOOL_VERSION="2.6"
+# ---
+# shellcheck disable=SC2068
+# shellcheck disable=SC2145
+# shellcheck disable=SC2027
+# shellcheck disable=SC2046
+# shellcheck disable=SC2125
+# shellcheck disable=SC2128
+# shellcheck disable=SC2166
+# shellcheck disable=SC2207
+# ---
+# For more information:
+# ---
+#  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
+#  https://www.shellcheck.net/wiki/SC2145 -- Argument mixes string and array. ...
+#  https://www.shellcheck.net/wiki/SC2027 -- The surrounding quotes actually u...
+#  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
+#  https://www.shellcheck.net/wiki/SC2125 -- Brace expansions and globs are li...
+#  https://www.shellcheck.net/wiki/SC2128 -- Expanding an array without an ind...
+#  https://www.shellcheck.net/wiki/SC2166 -- Prefer [ p ] && [ q ] as [ p -a q...
+#  https://www.shellcheck.net/wiki/SC2207 -- Prefer mapfile or read -a to spli...
+# ---
+PIHOLE_ADLIST_TOOL_VERSION="2.6.1"
 
 # define path to pihole's databases and temporary database
 TEMP_DB="/tmp/temp.db"
@@ -84,7 +105,8 @@ print_version() {
 
 # fetches latest version
 fetch_remote_version() {
-	local remote_version="$(
+	local remote_version
+	remote_version="$(
 		curl --silent https://api.github.com/repos/yubiuser/pihole_adlist_tool/releases/latest |
 		grep '"tag_name":' |
 		awk -F \" '{print $4}'
@@ -122,7 +144,8 @@ print_help() {
 #convert timestamp to date
 
 timestamp2date () {
-    local DATE=$(date -d @$1 +%d.%m.%Y%t%k:%M:%S)
+    local DATE
+    DATE=$(date -d @"$1" +%d.%m.%Y%t%k:%M:%S)
     echo "$DATE"
 }
 
@@ -131,8 +154,8 @@ timestamp2date () {
 
 set_timestamps () {
 
-    TIMESTAMP_FIRST_QUERY=$(sqlite $PIHOLE_FTL "SELECT MIN(timestamp) FROM queries;")
-    TIMESTAMP_LAST_QUERY=$(sqlite $PIHOLE_FTL "SELECT MAX(timestamp) FROM queries;")
+    TIMESTAMP_FIRST_QUERY=$(sqlite "$PIHOLE_FTL" "SELECT MIN(timestamp) FROM queries;")
+    TIMESTAMP_LAST_QUERY=$(sqlite "$PIHOLE_FTL" "SELECT MAX(timestamp) FROM queries;")
     if [ "$DAYS_REQUESTED" = 0 ];
         then
             TIMESTAMP_REQUESTED=$TIMESTAMP_FIRST_QUERY
@@ -140,16 +163,16 @@ set_timestamps () {
             TIMESTAMP_REQUESTED=$(date +%s)
             TIMESTAMP_REQUESTED=$TIMESTAMP_REQUESTED-86400*${DAYS_REQUESTED}
     fi
-    TIMESTAMP_FIRST_ANALYZED=$(sqlite $PIHOLE_FTL "SELECT min(timestamp) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
+    TIMESTAMP_FIRST_ANALYZED=$(sqlite "$PIHOLE_FTL" "SELECT min(timestamp) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
 }
 
 # converts dates
 
 set_dates () {
-    DATE_FIRST_QUERY="$(timestamp2date $TIMESTAMP_FIRST_QUERY)"
-    DATE_LAST_QUERY="$(timestamp2date $TIMESTAMP_LAST_QUERY)"
-    DATE_REQUESTED="$(timestamp2date $TIMESTAMP_REQUESTED)"
-    DATE_FIRST_ANALYZED="$(timestamp2date $TIMESTAMP_FIRST_ANALYZED)"
+    DATE_FIRST_QUERY="$(timestamp2date "$TIMESTAMP_FIRST_QUERY")"
+    DATE_LAST_QUERY="$(timestamp2date "$TIMESTAMP_LAST_QUERY")"
+    DATE_REQUESTED="$(timestamp2date "$TIMESTAMP_REQUESTED")"
+    DATE_FIRST_ANALYZED="$(timestamp2date "$TIMESTAMP_FIRST_ANALYZED")"
 
 }
 
@@ -168,8 +191,8 @@ EOF
 NUM_DOMAINS_BLOCKED_FUTURE=$(sqlite $TEMP_DB "SELECT value FROM info where property='NUM_DOMAINS_BLOCKED_FUTURE';")
 
 echo
-echo "  [✓]  Of the ${bold}"$NUM_DOMAINS_BLOCKED_CURRENT"${normal} domains that would have been blocked by the adlist configuration you chose to analyze,"
-echo "       ${bold}"$NUM_DOMAINS_BLOCKED_FUTURE"${normal} domains are covered by your current adlist configuration."
+echo "  [i]  Of the ${bold}$NUM_DOMAINS_BLOCKED_CURRENT${normal} domains that would have been blocked by the adlist configuration you chose to analyze,"
+echo "       ${bold}$NUM_DOMAINS_BLOCKED_FUTURE${normal} domains are covered by your current adlist configuration."
 
 }
 
@@ -181,16 +204,16 @@ if [ "$PIHOLE_DOCKER" = 0 ];
     then
          rm -f $TEMP_DB
     else
-        docker exec $CONTAINER_ID rm -f $TEMP_DB
+        docker exec "$CONTAINER_ID" rm -f $TEMP_DB
 fi
 
 
-echo -e "  [✓]  Temporary database removed\n"
+echo -e "  [i]  Temporary database removed\n"
 }
 
 # cleanup on trap
 cleanup_on_trap () {
-echo -e "\n\n  [✗]  ${bold}User-abort detected!${normal}"
+echo -e "\n\n  [x]  ${bold}User-abort detected!${normal}"
 remove_temp_database
 exit 1
 }
@@ -202,7 +225,7 @@ if [ "$PIHOLE_DOCKER" = 0 ];
     then
          pihole-FTL sqlite3 "$@"
     else
-        docker exec -i $CONTAINER_ID pihole-FTL sqlite3 "$@"
+        docker exec -i "$CONTAINER_ID" pihole-FTL sqlite3 "$@"
 fi
 
 }
@@ -257,7 +280,7 @@ if [ "$PIHOLE_DOCKER" = 0 ];
     then
         PIHOLE_DNSMASQ_VERSION=$(pihole-FTL -vv |awk '/dnsmasq/{getline; print substr($2,9)}')
     else
-        PIHOLE_DNSMASQ_VERSION=$(docker exec $CONTAINER_ID pihole-FTL -vv |awk '/dnsmasq/{getline; print substr($2,9)}')
+        PIHOLE_DNSMASQ_VERSION=$(docker exec "$CONTAINER_ID" pihole-FTL -vv |awk '/dnsmasq/{getline; print substr($2,9)}')
 fi
 
 
@@ -302,7 +325,7 @@ if [ "$PIHOLE_DOCKER" = 0 ];
     then
         SQLITE_VERSION=$(pihole-FTL sqlite3 --version|awk '{print $1}')
     else
-        SQLITE_VERSION=$(docker exec $CONTAINER_ID pihole-FTL sqlite3 --version|awk '{print $1}')
+        SQLITE_VERSION=$(docker exec "$CONTAINER_ID" pihole-FTL sqlite3 --version|awk '{print $1}')
 fi
 
 echo -e "  [i]  SQLITE_VERSION: $SQLITE_VERSION"
@@ -383,7 +406,7 @@ set_timestamps
 set_dates
 
 # get FTL_ID based on $TIMESTAMP_REQUESTED
-FTL_ID=$(sqlite $PIHOLE_FTL "SELECT MIN(id) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
+FTL_ID=$(sqlite "$PIHOLE_FTL" "SELECT MIN(id) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
 
 
 
@@ -391,8 +414,8 @@ FTL_ID=$(sqlite $PIHOLE_FTL "SELECT MIN(id) FROM queries WHERE timestamp>=$TIMES
 if [ "$TIMESTAMP_REQUESTED" -gt "$TIMESTAMP_LAST_QUERY" ];
     then
         echo
-        echo "  [i]  ${bold}Warning:${normal} You requested to analyze the last "${DAYS_REQUESTED}" day(s) (starting from "$DATE_REQUESTED"),"
-        echo "       but last query is from "$DATE_LAST_QUERY""
+        echo "  [i]  ${bold}Warning:${normal} You requested to analyze the last ${DAYS_REQUESTED} day(s) (starting from $DATE_REQUESTED),"
+        echo "       but last query is from $DATE_LAST_QUERY"
         echo "  [i]  Nothing to do here. Exiting "
         echo
         exit 0
@@ -401,14 +424,14 @@ fi
 if [ "$TIMESTAMP_REQUESTED" -lt "$TIMESTAMP_FIRST_QUERY" ];
     then
         echo
-        echo -e "  [i]  ${bold}Warning:${normal} You requested to analyze the last "${DAYS_REQUESTED}" days (starting from "$DATE_REQUESTED"),"
-        echo -e "       but oldest query is from "$DATE_FIRST_QUERY". Using this instead\n"
+        echo -e "  [i]  ${bold}Warning:${normal} You requested to analyze the last ""${DAYS_REQUESTED}"" days (starting from ""$DATE_REQUESTED""),"
+        echo -e "       but oldest query is from ""$DATE_FIRST_QUERY"". Using this instead\n"
         echo
 fi
 
 
 # save old adlist_configuration
-adlist_conf_old_enabled=(`sqlite $GRAVITY "select id from adlist where enabled=1;"`)
+adlist_conf_old_enabled=($(sqlite $GRAVITY "select id from adlist where enabled=1;"))
 
 echo "  Would you like to analyze your current adlist configuration or first enable all adlists (current can be restored later)?"
 echo
@@ -423,7 +446,7 @@ if [ "$AUTOMATIC_MODE" -eq 1 ];
 fi
 
 while [[ $ENABLE_ALL_ADLISTS_FOR_ANALYSIS != [12] ]]; do
-  read -p "  Please select: " ENABLE_ALL_ADLISTS_FOR_ANALYSIS
+  read -r -p "  Please select: " ENABLE_ALL_ADLISTS_FOR_ANALYSIS
 done
 echo
 echo
@@ -438,7 +461,7 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 1 ]; then
 
     # check if a mismatch between enabled adlists and data in gravity exists, offer to run gravity
     # https://stackoverflow.com/a/28161520
-    adlist_enabled_in_gravity=(`sqlite $GRAVITY "select distinct adlist_id from gravity;"`)
+    adlist_conf_old_enabled=($(sqlite $GRAVITY "select id from adlist where enabled=1;"))
     if [ -n "$(echo ${adlist_conf_old_enabled[@]} ${adlist_enabled_in_gravity[@]} | tr ' ' '\n' |sort |uniq -u)" ]; then
 
         echo
@@ -460,7 +483,7 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 1 ]; then
         fi
 
         while [[ $RUN_GRAVITY_NOW != [12] ]]; do
-            read -p "  Please select: " RUN_GRAVITY_NOW
+            read -r -p "  Please select: " RUN_GRAVITY_NOW
         done
         if [ "$RUN_GRAVITY_NOW" -eq 1 ]; then
                 echo
@@ -471,7 +494,7 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 1 ]; then
                      then
                         pihole -g
                     else
-                        docker exec $CONTAINER_ID pihole -g
+                        docker exec "$CONTAINER_ID" pihole -g
                 fi
 
                 echo
@@ -510,7 +533,7 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 2 ]; then
         then
             pihole -g
         else
-           docker exec $CONTAINER_ID pihole -g
+           docker exec "$CONTAINER_ID" pihole -g
     fi
     echo
     echo "  [✓]  Gravity update finished"
@@ -634,7 +657,7 @@ EOF
 
 # get some statistics
 # the number of domains blocked and hits is the sum of enties with status 1 or 9
-read NUM_DOMAINS_BLOCKED HITS_TOTAL <<<$(sqlite -separator " " $PIHOLE_FTL "SELECT COUNT(DISTINCT domain),count(domain) FROM queries WHERE id>=${FTL_ID} AND status in (1,9);")
+read -r NUM_DOMAINS_BLOCKED HITS_TOTAL <<<$(sqlite -separator " " "$PIHOLE_FTL" "SELECT COUNT(DISTINCT domain),count(domain) FROM queries WHERE id>=${FTL_ID} AND status in (1,9);")
 
 NUM_ADLISTS=$(sqlite $TEMP_DB "SELECT value FROM info where property='NUM_ADLISTS';")
 NUM_ADLISTS_ENABLED=$(sqlite $TEMP_DB "SELECT value FROM info where property='NUM_ADLISTS_ENABLED';")
@@ -647,11 +670,11 @@ NUM_GRAVITY_UNIQUE_DOMAINS=$(sqlite $GRAVITY "SELECT value FROM info WHERE prope
 
 
 echo
-echo "  [i]  You have ${bold}"$NUM_ADLISTS" adlists${normal} configured ("$NUM_ADLISTS_ENABLED" enabled)"
-echo "  [i]  Your gravity.db contains ${bold}"$NUM_GRAVITY_UNIQUE_DOMAINS" unique domains${normal}"
-echo "  [i]  Since "$DATE_FIRST_ANALYZED" ${bold}"$NUM_DOMAINS_BLOCKED" different domains${normal} from your adlists have been blocked ${bold}"$HITS_TOTAL" times${normal} in total"
+echo "  [i]  You have ${bold}""$NUM_ADLISTS"" adlists${normal} configured (""$NUM_ADLISTS_ENABLED"" enabled)"
+echo "  [i]  Your gravity.db contains ${bold}""$NUM_GRAVITY_UNIQUE_DOMAINS"" unique domains${normal}"
+echo "  [i]  Since ""$DATE_FIRST_ANALYZED"" ${bold}""$NUM_DOMAINS_BLOCKED"" different domains${normal} from your adlists have been blocked ${bold}""$HITS_TOTAL"" times${normal} in total"
 echo "       (blocked directly by gravity or during deep CNAME inspection)"
-echo "  [i]  Using you current adlist configuration ${bold}"$NUM_DOMAINS_BLOCKED_CURRENT" domains${normal} would have been blocked ${bold}"$HITS_TOTAL_CURRENT" times${normal}"
+echo "  [i]  Using you current adlist configuration ${bold}""$NUM_DOMAINS_BLOCKED_CURRENT"" domains${normal} would have been blocked ${bold}""$HITS_TOTAL_CURRENT"" times${normal}"
 
 echo
 echo
@@ -703,10 +726,10 @@ if [ "$TOP" = 0 ]; then :
     else
         echo
         echo "  [i]  ${bold}Top blocked adlist domains${normal}"
-        echo "       Those would have been the ${bold}"$TOP" top blocked adlist domains${normal} since "$DATE_FIRST_ANALYZED""
+        echo "       Those would have been the ${bold}""$TOP"" top blocked adlist domains${normal} since ""$DATE_FIRST_ANALYZED"""
         echo "       using your current adlist configuration"
         echo
-        sqlite -column -header $TEMP_DB "SELECT domain, hits FROM blocked_domains LIMIT "${TOP}";"
+        sqlite -column -header $TEMP_DB "SELECT domain, hits FROM blocked_domains LIMIT ""${TOP}"";"
         echo
         echo
         echo
@@ -732,7 +755,8 @@ echo "       As the same domains usually appears on more than one adlist the sum
 echo "       than the number of calculated blocked domains shown above"
 echo
 echo
-echo "  [i]  In total your adlists contain ${bold}"$NUM_TOTAL_UNIQUE_DOMAINS" visited (covered) unique domains${normal} - meaning those domains are contained only in a single adlist. "
+echo "  [i]  In total your adlists contain ${bold}$NUM_TOTAL_UNIQUE_DOMAINS visited (covered) unique domains${normal} - meaning those domains are contained only in a single adlist. "
+
 echo
 echo
 
@@ -753,7 +777,7 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 1 ];
         fi
 
         while [[ $FURTHER_ACTION != [123] ]]; do
-          read -p "  Please select: " FURTHER_ACTION
+          read -r -p "  Please select: " FURTHER_ACTION
         done
         if [ "$FURTHER_ACTION" -eq 1 ] && [ "$AUTOMATIC_MODE" -eq 0 ];
             then
@@ -770,7 +794,7 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 1 ];
         echo "  4)  Restore previous adlist configuration"
         echo
         while [[ $FURTHER_ACTION != [1234] ]]; do
-          read -p "  Please select: " FURTHER_ACTION
+          read -r -p "  Please select: " FURTHER_ACTION
         done
         if [ "$FURTHER_ACTION" -eq 1 ]; then
             echo
@@ -789,7 +813,7 @@ if [ "$FURTHER_ACTION" -eq 2 ]; then
            sqlite $GRAVITY "UPDATE adlist SET enabled=0;"
     fi
 
-    adlist_conf_unique_enabled=(`sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
+    adlist_conf_unique_enabled=($(sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"))
     for adlist_id in "${adlist_conf_unique_enabled[@]}"; do
 
         if [ "$PIHOLE_DOCKER" = 0 ];
@@ -804,7 +828,7 @@ if [ "$FURTHER_ACTION" -eq 2 ]; then
         then
             pihole restartdns reload-lists
         else
-            docker exec $CONTAINER_ID pihole restartdns reload-lists
+            docker exec "$CONTAINER_ID" pihole restartdns reload-lists
      fi
 
     echo
@@ -833,7 +857,7 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
     # remove all domains from gravity_dup that are also contained in that adlist
     # count how many domains are still on gravity_dup
 
-    adlist_conf_minimal_enabled=(`sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"`)
+    adlist_conf_minimal_enabled=($(sqlite $TEMP_DB "select id from adlist where unique_domains_covered IS NOT NULL;"))
 
     sqlite $TEMP_DB "CREATE TABLE gravity_dup AS SELECT * FROM gravity_strip"
 
@@ -841,14 +865,14 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$adlist_id);"
     done
 
-    LEFT_DOMAINS=(`sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"`)
+    LEFT_DOMAINS=($(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"))
 
     while [[ $LEFT_DOMAINS != [0] ]]; do
-        current_id=(`sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;"`);
+        current_id=($(sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;"));
 
         adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="$current_id"
         sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$current_id);"
-        LEFT_DOMAINS=(`sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"`)
+        LEFT_DOMAINS=($(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;"))
     done
 
     echo
@@ -868,7 +892,7 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
         then
             pihole restartdns reload-lists
         else
-            docker exec $CONTAINER_ID pihole restartdns reload-lists
+            docker exec "$CONTAINER_ID" pihole restartdns reload-lists
      fi
 
     echo
@@ -905,7 +929,7 @@ if [ "$FURTHER_ACTION" -eq 4 ]; then
         then
             pihole restartdns reload-lists
         else
-            docker exec $CONTAINER_ID pihole restartdns reload-lists
+            docker exec "$CONTAINER_ID" pihole restartdns reload-lists
      fi
     echo
     echo "  [✓]  Previous adlist configuration restored"
@@ -981,10 +1005,10 @@ EOF
 # NOTE: pihole-FTL regex-test will test also against RegEx whitelist BUT this is still much faster than to create a second loop to check against each RegEx blacklist indiviually
 
 
-        all_domains=(`sqlite $TEMP_DB "SELECT domain FROM all_domains"`)
+        all_domains=($(sqlite $TEMP_DB "SELECT domain FROM all_domains"))
 
         for CURRENT_DOMAIN in "${all_domains[@]}"; do
-                pihole-FTL regex-test $CURRENT_DOMAIN |grep -E -o "DB ID [0-9]*"|awk '{print $3}' | while read REGEX_ID; do
+                pihole-FTL regex-test "$CURRENT_DOMAIN" |grep -E -o "DB ID [0-9]*"|awk '{print $3}' | while read -r REGEX_ID; do
                     sqlite $TEMP_DB "INSERT INTO domain_by_regex(domain, regex_id) VALUES ('$CURRENT_DOMAIN',$REGEX_ID);"
             done
         done
@@ -1000,10 +1024,10 @@ EOF
 # for each domain check if it is covered by a RegEx (using pihole-FTL regex-test)
 # if the test returns regex_ids, save them in domainlist_regex
 
-        all_exact_domains=(`sqlite $GRAVITY "SELECT domain FROM domainlist WHERE type in (0,1);"`)
+        all_exact_domains=($(sqlite $GRAVITY "SELECT domain FROM domainlist WHERE type in (0,1);"))
 
         for CURRENT_DOMAIN in "${all_exact_domains[@]}"; do
-          pihole-FTL regex-test $CURRENT_DOMAIN |grep -E -o "DB ID [0-9]*"|awk '{print $3}' | while read REGEX_ID; do
+          pihole-FTL regex-test "$CURRENT_DOMAIN" |grep -E -o "DB ID [0-9]*"|awk '{print $3}' | while read -r REGEX_ID; do
               sqlite $TEMP_DB "INSERT INTO domainlist_regex(domain, regex_id) VALUES ('$CURRENT_DOMAIN',$REGEX_ID);"
             done
         done
@@ -1033,9 +1057,9 @@ EOF
         sqlite -column -header $TEMP_DB "SELECT id, enabled, domains_covered, regex FROM regex_black;"
         echo
         echo
-        echo "  [i]  Since "$DATE_FIRST_ANALYZED" you have been visiting ${bold}"$NUM_ALL_DOMAINS" different domains${normal}."
-        echo "       You have ${bold}"$NUM_REGEX" blacklist RegEx${normal} configured ("$NUM_ENABLED_REGEX" enabled)"
-        echo "       With your enabled blacklist RegEx you would have covered ${bold}"$NUM_DOMAINS_BLOCKED_BY_REGEX" different domains${normal}."
+        echo "  [i]  Since $DATE_FIRST_ANALYZED you have been visiting ${bold}$NUM_ALL_DOMAINS different domains${normal}."
+        echo "       You have ${bold}$NUM_REGEX blacklist RegEx${normal} configured ($NUM_ENABLED_REGEX enabled)"
+        echo "       With your enabled blacklist RegEx you would have covered ${bold}$NUM_DOMAINS_BLOCKED_BY_REGEX different domains${normal}."
         echo
         echo "  [i]  Please note: the internal Pi-hole RegEx test used here only checks domains against ${bold}enabled RegEx${normal}."
         echo "       Therefor, currently disabled RegEx will always have 0 domains covered."
@@ -1052,7 +1076,8 @@ EOF
             sqlite -column -header $TEMP_DB "SELECT * FROM domainlist_regex"
             echo
             echo
-            echo "       ${bold}"$NUM_DOMAINLIST_REGEX" distinct domain(s)${normal} from your domainlist are covered by your RegEx."
+            echo "       ${bold}$NUM_DOMAINLIST_REGEX distinct domain(s)${normal} from your domainlist are covered by your RegEx."
+
             echo "       Please note that this tool does not take into account if your domains and RegEx do match"
             echo "       regarding their black/whitelist status. E.g. a whitelisted domain that is covered by a blacklist RegEx"
             echo "       is counted and reported here as well."

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -35,7 +35,7 @@ declare -a adlist_conf_old_enabled
 declare -a adlist_conf_unique_enabled
 declare -a adlist_enabled_in_gravity
 declare -a adlist_conf_minimal_enabled
-LEFT_DOMAINS=
+declare -i LEFT_DOMAINS
 
 # variables for stats
 NUM_DOMAINS_BLOCKED=
@@ -845,7 +845,6 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$adlist_id);"
     done
 
-    declare -i LEFT_DOMAINS
     LEFT_DOMAINS=$(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
 
     while [[ ${LEFT_DOMAINS} != 0 ]]; do

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -845,10 +845,11 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
        sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=$adlist_id);"
     done
 
-    mapfile -t LEFT_DOMAINS < <(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
+    declare -i LEFT_DOMAINS
+    LEFT_DOMAINS=$(sqlite $TEMP_DB "SELECT COUNT (domain) from gravity_dup;")
 
     while [[ ${LEFT_DOMAINS[*]} != [0] ]]; do
-        mapfile -t current_id < <(sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;");
+        current_id=$(sqlite $TEMP_DB "Select adlist_id from gravity_dup group by adlist_id order by count (domain) desc, adlist_id asc limit 1;");
 
         adlist_conf_minimal_enabled[${#adlist_conf_minimal_enabled[@]}]="${current_id[*]}"
         sqlite $TEMP_DB "DELETE FROM gravity_dup WHERE domain IN (SELECT domain from gravity_dup where adlist_id=${current_id[*]});"

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -441,7 +441,7 @@ if [ "$ENABLE_ALL_ADLISTS_FOR_ANALYSIS" -eq 1 ]; then
 
     # check if a mismatch between enabled adlists and data in gravity exists, offer to run gravity
     # https://stackoverflow.com/a/28161520
-    mapfile -t adlist_enabled_in_gravity < <(sqlite "$GRAVITY" "select distinct adlist_id from gravity;")
+    mapfile -t adlist_enabled_in_gravity < <(sqlite $GRAVITY "select distinct adlist_id from gravity;")
     if [ -n "$(echo "${adlist_conf_old_enabled[@]}" "${adlist_enabled_in_gravity[@]}" | tr ' ' '\n' |sort |uniq -u)" ]; then
 
         echo

--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -857,7 +857,7 @@ if [ "$FURTHER_ACTION" -eq 3 ]; then
     done
 
     echo
-    echo "  [i]  Enabling adlists with id ${adlist_conf_minimal_enabled[@]}"
+    echo "  [i]  Enabling adlists with id" "${adlist_conf_minimal_enabled[@]}"
 
     for adlist_id in "${adlist_conf_minimal_enabled[@]}"; do
 


### PR DESCRIPTION
This fixes and closes issue #36.
I checked/validated by running `pihole_adlist_tool -d 1 -t 10 -u -a` with old and new version and diff'ed the results:
```
$ sdiff -s old new
							      >	  [i]  There is a mismatch between your enabled adlists and t
							      >	       You have 30 adlists enabled, but data from 0
                                                                                                                   							      >	       You're likely disabled/enabled adlist without running
							      >	       It's highly recommended to run gravity now to solve th
							      >
							      >
							      >	  Would you like to run gravity now?
							      >
							      >	  1)  Yes
							      >	  2)  No
							      >
							      >	  [i]  Running in automatic mode, not running gravity.
							      >
							      >
							      >
  [i]  Since 19.01.2022 18:59:55 529 different domains |	  [i]  Since 19.01.2022	19:00:09 529 different domains
  [i]  Using you current adlist configuration 551 domains|	  [i]  Using you current adlist configuration 551 domains
                                                                                                                                Those would have been the 10 top blocked adlist dom |	       Those would have been the 10 top blocked adlist dom
gs-loc.ls-apple.com.akadns.net       618 		      |	gs-loc.ls-apple.com.akadns.net       620
self.events.data.microsoft.com       353 		      |	self.events.data.microsoft.com       354
1   1        97346          273              6156          8  |	1   1        97346          273              6160          8
36  1        1095098        301              5678          35 |	36  1        1095098        301              5682          35
43  1        1026181        98               2864          6  |	43  1        1026181        98               2868          6
61  1        234            61               3534          51 |	61  1        234            61               3538          51
63  1        404455         355              10451         55 |	63  1        404455         355              10456         55
  [✓]  Temporary database removed			      |	  [i]  Temporary database remove
```

For privacy reasons I can't get you full output. Maybe you can check this with your Pi-Hole… 🤔 