### PR TITLE
Add -r option to Usage section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ options:
     -u                               Show covered unique domains
     -a                               Run in 'automatic mode'. No user input is required at all, assuming default choice would be to leave everything untouched.
 le_adlist_tool's version.
+    -r                               Include regex blacklist domains in analysis
     -h                               Show this help dialog
 
 ```


### PR DESCRIPTION
I noticed the -r option was added but looked like it was missing from the Usage section of the README.

Please feel free to adjust the wording describing the option however makes most sense to you! Just thought I’d help get the change started!