### PR TITLE
🩹 fix deprecation warning: Node.js 12 actions are deprecated.

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       # Required to access files of this repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Download Shellcheck and add it to the workflow path
       - name: Download Shellcheck


### PR DESCRIPTION
For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: actions/checkout@master
Using version v3, latest or master: actions/checkout#689