### PR TITLE
Fix Pi-hole v6 using nanosecond timestamps

### DIFF
--- a/pihole_adlist_tool
+++ b/pihole_adlist_tool
@@ -135,8 +135,10 @@ timestamp2date () {
 
 set_timestamps () {
 
-    TIMESTAMP_FIRST_QUERY=$(sqlite "$PIHOLE_FTL" "SELECT MIN(timestamp) FROM queries;")
-    TIMESTAMP_LAST_QUERY=$(sqlite "$PIHOLE_FTL" "SELECT MAX(timestamp) FROM queries;")
+
+    TIMESTAMP_FIRST_QUERY=$(sqlite "$PIHOLE_FTL" "SELECT CAST(MIN(timestamp) AS INTEGER) FROM queries;")
+    TIMESTAMP_LAST_QUERY=$(sqlite "$PIHOLE_FTL" "SELECT CAST(MAX(timestamp) AS INTEGR) FROM queries;")
+
     if [ "$DAYS_REQUESTED" = 0 ];
         then
             TIMESTAMP_REQUESTED=$TIMESTAMP_FIRST_QUERY
@@ -144,7 +146,7 @@ set_timestamps () {
             TIMESTAMP_REQUESTED=$(date +%s)
             TIMESTAMP_REQUESTED="$TIMESTAMP_REQUESTED-86400*${DAYS_REQUESTED}"
     fi
-    TIMESTAMP_FIRST_ANALYZED=$(sqlite "$PIHOLE_FTL" "SELECT min(timestamp) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
+    TIMESTAMP_FIRST_ANALYZED=$(sqlite "$PIHOLE_FTL" "SELECT CAST(min(timestamp) AS INTEGER) FROM queries WHERE timestamp>=$TIMESTAMP_REQUESTED;")
 }
 
 # converts dates


### PR DESCRIPTION
Fixes an issue where the tool won't work on Pi-hole v6 due to the database timestaps being saved with nanosecond precision. 

Fixes https://github.com/yubiuser/pihole_adlist_tool/issues/88#event-16490595404

---
**By submitting this pull request, I confirm the following:**

1. I have commented my proposed changes within the code and I have tested my changes.
2. I am willing to help maintain this change if there are issues with it later.
3. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
4. I have checked that another pull request for this purpose does not exist.
5. I have considered, and confirmed that this submission will be valuable to others.
6. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
7. I give this submission freely, and claim no ownership to its content.

---

- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
